### PR TITLE
Merge changes

### DIFF
--- a/backport/backport-include/linux/debugfs.h
+++ b/backport/backport-include/linux/debugfs.h
@@ -49,4 +49,19 @@ debugfs_leave_cancellation(struct file *file,
 }
 #endif /* <6.7 */
 
+#if LINUX_VERSION_IS_LESS(6,13,0)
+#define debugfs_short_fops file_operations
+#endif
+
+#if LINUX_VERSION_IS_LESS(6,14,0)
+#define debugfs_change_name(dir, fmt, ...) \
+	({ \
+		char *__new_name = kasprintf(GFP_KERNEL, fmt, ##__VA_ARGS__); \
+		struct dentry *__d = debugfs_rename((dir)->d_parent, dir, (dir)->d_parent, __new_name); \
+		kfree(__new_name); \
+		PTR_ERR_OR_ZERO(__d); \
+	})
+#endif
+
+
 #endif /* __BACKPORT_DEBUGFS_H_ */

--- a/backport/backport-include/linux/export.h
+++ b/backport/backport-include/linux/export.h
@@ -5,6 +5,10 @@
 
 #include_next <linux/export.h>
 
+#if LINUX_VERSION_IS_LESS(6,13,0)
+#undef EXPORT_SYMBOL_NS_GPL
+#endif
+
 #ifndef EXPORT_SYMBOL_NS_GPL
 #define EXPORT_SYMBOL_NS_GPL(sym, ns) EXPORT_SYMBOL_GPL(sym)
 #endif

--- a/backport/backport-include/net/netlink.h
+++ b/backport/backport-include/net/netlink.h
@@ -385,4 +385,126 @@ MIN_LEN_VALIDATION(42)
 	.range = (struct netlink_range_validation *)_range, \
 }
 
+#if LINUX_VERSION_IS_LESS(6,13,0)
+static inline u32 nla_get_u32_default(const struct nlattr *nla, u32 defvalue)
+{
+	if (!nla)
+		return defvalue;
+	return nla_get_u32(nla);
+}
+
+static inline __be32 nla_get_be32_default(const struct nlattr *nla,
+					  __be32 defvalue)
+{
+	if (!nla)
+		return defvalue;
+	return nla_get_be32(nla);
+}
+
+static inline __le32 nla_get_le32_default(const struct nlattr *nla,
+					  __le32 defvalue)
+{
+	if (!nla)
+		return defvalue;
+	return nla_get_le32(nla);
+}
+
+static inline u16 nla_get_u16_default(const struct nlattr *nla, u16 defvalue)
+{
+	if (!nla)
+		return defvalue;
+	return nla_get_u16(nla);
+}
+static inline __be16 nla_get_be16_default(const struct nlattr *nla,
+					  __be16 defvalue)
+{
+	if (!nla)
+		return defvalue;
+	return nla_get_be16(nla);
+}
+
+static inline __le16 nla_get_le16_default(const struct nlattr *nla,
+					  __le16 defvalue)
+{
+	if (!nla)
+		return defvalue;
+	return nla_get_le16(nla);
+}
+
+static inline u8 nla_get_u8_default(const struct nlattr *nla, u8 defvalue)
+{
+	if (!nla)
+		return defvalue;
+	return nla_get_u8(nla);
+}
+
+static inline u64 nla_get_u64_default(const struct nlattr *nla, u64 defvalue)
+{
+	if (!nla)
+		return defvalue;
+	return nla_get_u64(nla);
+}
+
+static inline __be64 nla_get_be64_default(const struct nlattr *nla,
+					  __be64 defvalue)
+{
+	if (!nla)
+		return defvalue;
+	return nla_get_be64(nla);
+}
+
+static inline __le64 nla_get_le64_default(const struct nlattr *nla,
+					  __le64 defvalue)
+{
+	if (!nla)
+		return defvalue;
+	return nla_get_le64(nla);
+}
+
+static inline s32 nla_get_s32_default(const struct nlattr *nla, s32 defvalue)
+{
+	if (!nla)
+		return defvalue;
+	return nla_get_s32(nla);
+}
+
+static inline s16 nla_get_s16_default(const struct nlattr *nla, s16 defvalue)
+{
+	if (!nla)
+		return defvalue;
+	return nla_get_s16(nla);
+}
+
+static inline s8 nla_get_s8_default(const struct nlattr *nla, s8 defvalue)
+{
+	if (!nla)
+		return defvalue;
+	return nla_get_s8(nla);
+}
+
+static inline s64 nla_get_s64_default(const struct nlattr *nla, s64 defvalue)
+{
+	if (!nla)
+		return defvalue;
+	return nla_get_s64(nla);
+}
+
+static inline __be32 nla_get_in_addr_default(const struct nlattr *nla,
+					     __be32 defvalue)
+{
+	if (!nla)
+		return defvalue;
+	return nla_get_in_addr(nla);
+}
+
+static inline unsigned long nla_get_msecs_default(const struct nlattr *nla,
+						  unsigned long defvalue)
+{
+	if (!nla)
+		return defvalue;
+	return nla_get_msecs(nla);
+}
+
+#endif /* < 6.13 */
+
 #endif /* __BACKPORT_NET_NETLINK_H */

--- a/copy-list
+++ b/copy-list
@@ -52,7 +52,6 @@ include/uapi/linux/virtio_ids.h
 include/net/cfg80211.h
 include/net/cfg80211-wext.h
 include/net/ieee80211_radiotap.h
-include/net/lib80211.h
 include/net/mac80211.h
 include/net/regulatory.h
 include/net/codel.h

--- a/patches/0004-disable-wext-kconfig.patch
+++ b/patches/0004-disable-wext-kconfig.patch
@@ -3,7 +3,7 @@ so remove the Kconfig options for them.
 
 --- a/net/wireless/Kconfig
 +++ b/net/wireless/Kconfig
-@@ -1,22 +1,4 @@
+@@ -1,19 +1,4 @@
  # SPDX-License-Identifier: GPL-2.0-only
 -config WIRELESS_EXT
 -	bool
@@ -17,9 +17,6 @@ so remove the Kconfig options for them.
 -	depends on PROC_FS
 -	depends on WEXT_CORE
 -
--config WEXT_SPY
--	bool
--
 -config WEXT_PRIV
 -	bool
 -
@@ -29,9 +26,9 @@ so remove the Kconfig options for them.
 @@ -189,7 +171,7 @@ config CFG80211_CRDA_SUPPORT
  
  config CFG80211_WEXT
- 	bool "cfg80211 wireless extensions compatibility" if !CFG80211_WEXT_EXPORT
+ 	bool "cfg80211 wireless extensions compatibility"
 -	select WEXT_CORE
 +	depends on WEXT_CORE
- 	default y if CFG80211_WEXT_EXPORT
  	help
  	  Enable this option if you need old userspace for wireless
+ 

--- a/patches/0006-pcim_request_all_regions.patch
+++ b/patches/0006-pcim_request_all_regions.patch
@@ -1,0 +1,36 @@
+--- a/drivers/net/wireless/intel/iwlwifi/pcie/trans.c
++++ b/drivers/net/wireless/intel/iwlwifi/pcie/trans.c
+@@ -3785,6 +3785,9 @@ struct iwl_trans *iwl_trans_pcie_alloc(s
+ {
+ 	struct iwl_trans_pcie *trans_pcie, **priv;
+ 	struct iwl_trans *trans;
++#if LINUX_VERSION_IS_LESS(6,13,0)
++	void __iomem * const *table;
++#endif
+ 	int ret, addr_size;
+ 	u32 bar0;
+ 
+@@ -3911,13 +3914,23 @@ struct iwl_trans *iwl_trans_pcie_alloc(s
+ 		}
+ 	}
+ 
++#if LINUX_VERSION_IS_GEQ(6,13,0)
+ 	ret = pcim_request_all_regions(pdev, DRV_NAME);
++#else
++	ret = pcim_iomap_regions_request_all(pdev, BIT(0), DRV_NAME);
++#endif
+ 	if (ret) {
+ 		dev_err(&pdev->dev, "Requesting all PCI BARs failed.\n");
+ 		goto out_no_pci;
+ 	}
+ 
++#if LINUX_VERSION_IS_GEQ(6,13,0)
+ 	trans_pcie->hw_base = pcim_iomap(pdev, 0, 0);
++#else
++	table = pcim_iomap_table(pdev);
++	if (table)
++		trans_pcie->hw_base = table[0];
++#endif
+ 	if (!trans_pcie->hw_base) {
+ 		dev_err(&pdev->dev, "Could not ioremap PCI BAR 0.\n");
+ 		ret = -ENODEV;

--- a/patches/0084-disable-some-staging-dirs.patch
+++ b/patches/0084-disable-some-staging-dirs.patch
@@ -6,6 +6,6 @@
  
 -obj-y				+= media/
 +#obj-y				+= media/
- obj-$(CONFIG_FB_OLPC_DCON)	+= olpc_dcon/
- obj-$(CONFIG_RTL8192E)		+= rtl8192e/
  obj-$(CONFIG_RTL8723BS)		+= rtl8723bs/
+ obj-$(CONFIG_OCTEON_ETHERNET)	+= octeon/
+ obj-$(CONFIG_VME_BUS)		+= vme_user/

--- a/patches/0100-platform_driver_remove.cocci
+++ b/patches/0100-platform_driver_remove.cocci
@@ -1,0 +1,27 @@
+@r@
+identifier OPS;
+identifier platform_driver_remove;
+fresh identifier platform_driver_remove_wrap = "bp_" ## platform_driver_remove;
+position p;
+@@
+struct platform_driver OPS@p = {
++#if LINUX_VERSION_IS_GEQ(6,11,0)
+	.remove = platform_driver_remove,
++#else
++	.remove = platform_driver_remove_wrap,
++#endif
+};
+
+@@
+identifier r.platform_driver_remove_wrap;
+identifier r.platform_driver_remove;
+@@
+void platform_driver_remove(...) {...}
++#if LINUX_VERSION_IS_LESS(6,11,0)
++static int platform_driver_remove_wrap(struct spi_device *spi)
++{
++	platform_driver_remove(spi);
++
++	return 0;
++}
++#endif


### PR DESCRIPTION
## Summary by Sourcery

Add backport compatibility functions and macros for Linux kernel versions before 6.13 and 6.14

Enhancements:
- Add default value retrieval functions for netlink attributes for various data types
- Add debugfs-related compatibility macros
- Add export symbol namespace compatibility macro

Chores:
- Add a Coccinelle patch for platform driver remove compatibility
- Modify backport include headers